### PR TITLE
Fix for Proguad Rules

### DIFF
--- a/BreadPartnersSDK/consumer-rules.pro
+++ b/BreadPartnersSDK/consumer-rules.pro
@@ -37,7 +37,7 @@
 -keep class androidx.multidex.** { *; }
 
 # Or keep all classes in a package public
--keep public class com.breadfinancial.breadpartners.sdk.core.** { *; }
+-keep public class com.breadfinancial.breadpartners.sdk.** { *; }
 
 # Suppress general warnings for smooth builds
 -dontwarn javax.annotation.**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.3.1"
-kotlin = "2.1.0"
+kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.3.1"
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
Before only classes belonging to core folder in SDK were protected from changing during obfuscation process. That caused issues with parcing responses to PlacementsResponse and RTPSResponse because they belong to networking.models folder, not core folder.