### PR TITLE
oc-230 changing the defaults color with PlacementsConfiguration.kt 

### DIFF
--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -14,6 +14,7 @@ package com.breadfinancial.breadpartners.sdk.core.models
 
 import android.graphics.Color
 import android.graphics.Typeface
+import com.breadfinancial.breadpartners.sdk.utilities.BreadPartnerDefaults
 
 /**
  * Data class that provides configurations for the `registerPlacement` or `submitRTPS` methods.
@@ -40,14 +41,14 @@ data class PopUpStyling(
     val crossColor: Int = Color.BLACK,
     val dividerColor: Int = Color.LTGRAY,
     val borderColor: Int = Color.BLACK,
-    val titlePopupTextStyle: PopupTextStyle,
-    val subTitlePopupTextStyle: PopupTextStyle,
-    val headerPopupTextStyle: PopupTextStyle,
+    val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val subTitlePopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val headerPopupTextStyle: PopupTextStyle = PopupTextStyle(),
     val headerBgColor: Int = Color.LTGRAY,
-    val headingThreePopupTextStyle: PopupTextStyle,
-    val paragraphPopupTextStyle: PopupTextStyle,
-    val connectorPopupTextStyle: PopupTextStyle,
-    val disclosurePopupTextStyle: PopupTextStyle,
+    val headingThreePopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val paragraphPopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val connectorPopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val disclosurePopupTextStyle: PopupTextStyle = PopupTextStyle(),
     var actionButtonStyle: PopupActionButtonStyle? = null,
 )
 
@@ -59,7 +60,9 @@ data class PopUpStyling(
  * - `textSize`: Specifies the size of the text.
  */
 data class PopupTextStyle(
-    val font: Typeface? = null, val textColor: Int? = null, val textSize: Float? = null
+    val font: Typeface? = null,
+    val textColor: Int = BreadPartnerDefaults.grayColor,
+    val textSize: Float? = null
 )
 
 /**

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -41,16 +41,34 @@ data class PopUpStyling(
     val crossColor: Int = Color.BLACK,
     val dividerColor: Int = Color.LTGRAY,
     val borderColor: Int = Color.BLACK,
-    val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    val subTitlePopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    val headerPopupTextStyle: PopupTextStyle = PopupTextStyle(),
+    val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textColor = Color.BLACK,
+        textSize = 16.0f
+    ),
+    val subTitlePopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textSize = 12.0f
+    ),
+    val headerPopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textSize = 14.0f
+    ),
     val headerBgColor: Int = Color.LTGRAY,
-    val headingThreePopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    val paragraphPopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    val connectorPopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    val disclosurePopupTextStyle: PopupTextStyle = PopupTextStyle(),
-    var actionButtonStyle: PopupActionButtonStyle? = null,
+    val headingThreePopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textColor = Color.BLACK,
+        textSize = 14.0f
+    ),
+    val paragraphPopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textSize = 10.0f
+    ),
+    val connectorPopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textColor = Color.BLACK,
+        textSize = 14.0f
+    ),
+    val disclosurePopupTextStyle: PopupTextStyle = PopupTextStyle(
+        textSize = 10.0f
+    ),
+    var actionButtonStyle: PopupActionButtonStyle? = PopupActionButtonStyle(),
 )
+
 
 /**
  * Structure that defines text styling config for popup elements.
@@ -60,8 +78,8 @@ data class PopUpStyling(
  * - `textSize`: Specifies the size of the text.
  */
 data class PopupTextStyle(
-    val font: Typeface? = null,
-    val textColor: Int = BreadPartnerDefaults.grayColor,
+    val font: Typeface? = Typeface.create(Typeface.DEFAULT, Typeface.BOLD),
+    val textColor: Int? = BreadPartnerDefaults.grayColor,
     val textSize: Float? = null
 )
 

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -43,28 +43,28 @@ data class PopUpStyling(
     val borderColor: Int = Color.BLACK,
     val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(
         textColor = Color.BLACK,
-        textSize = 16.0f
+        textSize = BreadPartnerDefaults.TITLE_POPUP_TEXT_SIZE
     ),
     val subTitlePopupTextStyle: PopupTextStyle = PopupTextStyle(
-        textSize = 12.0f
+        textSize = BreadPartnerDefaults.SUBTITLE_POPUP_TEXT_SIZE
     ),
     val headerPopupTextStyle: PopupTextStyle = PopupTextStyle(
-        textSize = 14.0f
+        textSize = BreadPartnerDefaults.HEADER_POPUP_TEXT_SIZE
     ),
     val headerBgColor: Int = Color.LTGRAY,
     val headingThreePopupTextStyle: PopupTextStyle = PopupTextStyle(
         textColor = Color.BLACK,
-        textSize = 14.0f
+        textSize = BreadPartnerDefaults.HEADING_THREE_POPUP_TEXT_SIZE
     ),
     val paragraphPopupTextStyle: PopupTextStyle = PopupTextStyle(
-        textSize = 10.0f
+        textSize = BreadPartnerDefaults.PARAGRAPH_POPUP_TEXT_SIZE
     ),
     val connectorPopupTextStyle: PopupTextStyle = PopupTextStyle(
         textColor = Color.BLACK,
-        textSize = 14.0f
+        textSize = BreadPartnerDefaults.CONNECTOR_POPUP_TEXT_SIZE
     ),
     val disclosurePopupTextStyle: PopupTextStyle = PopupTextStyle(
-        textSize = 10.0f
+        textSize = BreadPartnerDefaults.DISCLOSURE_POPUP_TEXT_SIZE
     ),
     var actionButtonStyle: PopupActionButtonStyle? = PopupActionButtonStyle(),
 )
@@ -79,7 +79,7 @@ data class PopUpStyling(
  */
 data class PopupTextStyle(
     val font: Typeface? = Typeface.create(Typeface.DEFAULT, Typeface.BOLD),
-    val textColor: Int? = BreadPartnerDefaults.grayColor,
+    val textColor: Int? = BreadPartnerDefaults.GRAY_COLOR,
     val textSize: Float? = null
 )
 

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -99,6 +99,6 @@ data class PopupActionButtonStyle(
     val textColor: Int = Color.WHITE,
     val textSize: Float = 12F,
     val backgroundColor: Int = Color.BLACK,
-    val cornerRadius: Float = 60.0F
+    val cornerRadius: Float = BreadPartnerDefaults.ACTION_BUTTON_CORNER_RADIUS
 )
 

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -66,7 +66,7 @@ data class PopUpStyling(
     val disclosurePopupTextStyle: PopupTextStyle = PopupTextStyle(
         textSize = BreadPartnerDefaults.DISCLOSURE_POPUP_TEXT_SIZE
     ),
-    var actionButtonStyle: PopupActionButtonStyle? = PopupActionButtonStyle(),
+    var actionButtonStyle: PopupActionButtonStyle = PopupActionButtonStyle(),
 )
 
 

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -15,6 +15,7 @@ package com.breadfinancial.breadpartners.sdk.core.models
 import android.graphics.Color
 import android.graphics.Typeface
 import com.breadfinancial.breadpartners.sdk.utilities.BreadPartnerDefaults
+import com.breadfinancial.breadpartners.sdk.utilities.BreadPartnerDefaults.Companion.LIGHT_GRAY_COLOR
 
 /**
  * Data class that provides configurations for the `registerPlacement` or `submitRTPS` methods.
@@ -39,8 +40,8 @@ data class PlacementsConfiguration(
 data class PopUpStyling(
     val loaderColor: Int = Color.BLACK,
     val crossColor: Int = Color.BLACK,
-    val dividerColor: Int = Color.LTGRAY,
-    val borderColor: Int = Color.BLACK,
+    val dividerColor: Int = LIGHT_GRAY_COLOR,
+    val borderColor: Int = LIGHT_GRAY_COLOR,
     val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(
         textColor = Color.BLACK,
         textSize = BreadPartnerDefaults.TITLE_POPUP_TEXT_SIZE

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
@@ -20,17 +20,18 @@ import com.breadfinancial.breadpartners.sdk.R
 import com.breadfinancial.breadpartners.sdk.core.models.PopUpStyling
 import com.breadfinancial.breadpartners.sdk.core.models.PopupActionButtonStyle
 import com.breadfinancial.breadpartners.sdk.core.models.PopupTextStyle
+import androidx.core.graphics.toColorInt
 
 /**
  * `BreadPartnerDefaults` class provides default configurations/styles/properties
  * used across the BreadPartner SDK.
  */
 class BreadPartnerDefaults private constructor() {
-
     companion object {
         val shared: BreadPartnerDefaults by lazy { BreadPartnerDefaults() }
+        // Default color used for gray text to match with web SDK.
+        val grayColor = "#767676".toColorInt()
     }
-
     // region Default Popup Style
     fun createPopUpStyling(context: Context): PopUpStyling {
         return PopUpStyling(
@@ -41,45 +42,60 @@ class BreadPartnerDefaults private constructor() {
             titlePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.BLACK, textSize = 16.0f
+                ),
+                textColor = Color.BLACK,
+                textSize = 16.0f
             ),
             subTitlePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.GRAY, textSize = 12.0f
+                ),
+                textColor = grayColor,
+                textSize = 12.0f
             ),
             headerPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.GRAY, textSize = 14.0f
+                ),
+                textColor = grayColor,
+                textSize = 14.0f
             ),
             headerBgColor = Color.parseColor("#ececec"),
             headingThreePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.parseColor("#d50132"), textSize = 14.0f
+                ),
+                textColor = Color.BLACK,
+                textSize = 14.0f
             ),
             paragraphPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.GRAY, textSize = 10.0f
+                ),
+                textColor = grayColor,
+                textSize = 10.0f
             ),
             connectorPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.BLACK, textSize = 14.0f
+                ),
+                textColor = Color.BLACK,
+                textSize = 14.0f
             ),
             disclosurePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
-                    ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
-                ), textColor = Color.GRAY, textSize = 10.0f
+                    ResourcesCompat.getFont(context, R.font.arial_regular),
+                    Typeface.BOLD
+                ),
+                textColor = grayColor,
+                textSize = 10.0f
             ),
             actionButtonStyle = PopupActionButtonStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
                 textColor = Color.WHITE,
-                backgroundColor = Color.parseColor("#d50132"),
+                backgroundColor = Color.BLACK,
                 cornerRadius = 60.0F,
             )
         )

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
@@ -30,7 +30,14 @@ class BreadPartnerDefaults private constructor() {
     companion object {
         val shared: BreadPartnerDefaults by lazy { BreadPartnerDefaults() }
         // Default color used for gray text to match with web SDK.
-        val grayColor = "#767676".toColorInt()
+        val GRAY_COLOR = "#767676".toColorInt()
+        const val TITLE_POPUP_TEXT_SIZE = 16.0f
+        const val SUBTITLE_POPUP_TEXT_SIZE = 12.0f
+        const val HEADER_POPUP_TEXT_SIZE = 14.0f
+        const val HEADING_THREE_POPUP_TEXT_SIZE = 14.0f
+        const val PARAGRAPH_POPUP_TEXT_SIZE = 10.0f
+        const val CONNECTOR_POPUP_TEXT_SIZE = 14.0f
+        const val DISCLOSURE_POPUP_TEXT_SIZE = 10.0f
     }
     // region Default Popup Style
     fun createPopUpStyling(context: Context): PopUpStyling {
@@ -44,21 +51,21 @@ class BreadPartnerDefaults private constructor() {
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
                 textColor = Color.BLACK,
-                textSize = 16.0f
+                textSize = TITLE_POPUP_TEXT_SIZE
             ),
             subTitlePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
-                textColor = grayColor,
-                textSize = 12.0f
+                textColor = GRAY_COLOR,
+                textSize = SUBTITLE_POPUP_TEXT_SIZE
             ),
             headerPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
-                textColor = grayColor,
-                textSize = 14.0f
+                textColor = GRAY_COLOR,
+                textSize = HEADER_POPUP_TEXT_SIZE
             ),
             headerBgColor = Color.parseColor("#ececec"),
             headingThreePopupTextStyle = PopupTextStyle(
@@ -66,29 +73,29 @@ class BreadPartnerDefaults private constructor() {
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
                 textColor = Color.BLACK,
-                textSize = 14.0f
+                textSize = HEADING_THREE_POPUP_TEXT_SIZE
             ),
             paragraphPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
-                textColor = grayColor,
-                textSize = 10.0f
+                textColor = GRAY_COLOR,
+                textSize = PARAGRAPH_POPUP_TEXT_SIZE
             ),
             connectorPopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
                 ),
                 textColor = Color.BLACK,
-                textSize = 14.0f
+                textSize = CONNECTOR_POPUP_TEXT_SIZE
             ),
             disclosurePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular),
                     Typeface.BOLD
                 ),
-                textColor = grayColor,
-                textSize = 10.0f
+                textColor = GRAY_COLOR,
+                textSize = DISCLOSURE_POPUP_TEXT_SIZE
             ),
             actionButtonStyle = PopupActionButtonStyle(
                 font = Typeface.create(

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
@@ -31,6 +31,7 @@ class BreadPartnerDefaults private constructor() {
         val shared: BreadPartnerDefaults by lazy { BreadPartnerDefaults() }
         // Default color used for gray text to match with web SDK.
         val GRAY_COLOR = "#767676".toColorInt()
+        val LIGHT_GRAY_COLOR = "#ececec".toColorInt()
         const val TITLE_POPUP_TEXT_SIZE = 16.0f
         const val SUBTITLE_POPUP_TEXT_SIZE = 12.0f
         const val HEADER_POPUP_TEXT_SIZE = 14.0f
@@ -44,8 +45,8 @@ class BreadPartnerDefaults private constructor() {
         return PopUpStyling(
             loaderColor = Color.parseColor("#0f2233"),
             crossColor = Color.BLACK,
-            dividerColor = Color.parseColor("#ececec"),
-            borderColor = Color.parseColor("#ececec"),
+            dividerColor = LIGHT_GRAY_COLOR,
+            borderColor =LIGHT_GRAY_COLOR,
             titlePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD
@@ -67,7 +68,7 @@ class BreadPartnerDefaults private constructor() {
                 textColor = GRAY_COLOR,
                 textSize = HEADER_POPUP_TEXT_SIZE
             ),
-            headerBgColor = Color.parseColor("#ececec"),
+            headerBgColor = LIGHT_GRAY_COLOR,
             headingThreePopupTextStyle = PopupTextStyle(
                 font = Typeface.create(
                     ResourcesCompat.getFont(context, R.font.arial_regular), Typeface.BOLD

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/utilities/BreadPartnerDefaults.kt
@@ -39,6 +39,7 @@ class BreadPartnerDefaults private constructor() {
         const val PARAGRAPH_POPUP_TEXT_SIZE = 10.0f
         const val CONNECTOR_POPUP_TEXT_SIZE = 14.0f
         const val DISCLOSURE_POPUP_TEXT_SIZE = 10.0f
+        const val ACTION_BUTTON_CORNER_RADIUS = 30.0f
     }
     // region Default Popup Style
     fun createPopUpStyling(context: Context): PopUpStyling {
@@ -104,7 +105,7 @@ class BreadPartnerDefaults private constructor() {
                 ),
                 textColor = Color.WHITE,
                 backgroundColor = Color.BLACK,
-                cornerRadius = 60.0F,
+                cornerRadius = ACTION_BUTTON_CORNER_RADIUS,
             )
         )
     }


### PR DESCRIPTION
PlacementsConfiguration.kt
- Added PopUpStyling data class with color properties (loaderColor, crossColor, dividerColor, borderColor, headerBgColor) and text style properties for multiple elements (titlePopupTextStyle, subTitlePopupTextStyle, headerPopupTextStyle, headingThreePopupTextStyle, paragraphPopupTextStyle, connectorPopupTextStyle, disclosurePopupTextStyle)
- Added PopupTextStyle data class with font, textColor, and textSize properties
-Added PopupActionButtonStyle data class with font, textColor, textSize, backgroundColor, and cornerRadius properties
- Updated PlacementsConfiguration to include optional popUpStyling property
- 
BreadPartnerDefaults.kt
-Added grayColor constant (#767676) for consistent gray text rendering
-Added createPopUpStyling(Context) factory method that returns PopUpStyling with predefined values including Arial Bold -fonts, hex colors (#0f2233, #ececec), and text sizes (10-16f)

Before:
<img width="1179" height="2556" alt="image (1)" src="https://github.com/user-attachments/assets/18f1c407-5610-4f8f-8e4d-bdc29a766160" />

After:
<img width="541" height="1161" alt="Screenshot 2026-06-25 at 10 55 44 AM" src="https://github.com/user-attachments/assets/37ecdfaf-a531-49ee-8995-09d62059d650" />



