### PR TITLE
Fixing "Back to top" color.

### DIFF
--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
@@ -62,8 +62,8 @@ private fun TextView.makeLinksClickable(onLinkClicked: (url: String) -> Unit) {
                 onLinkClicked(url)
             }
             override fun updateDrawState(ds: TextPaint) {
-                super.updateDrawState(ds)
                 ds.isUnderlineText = true
+                ds.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
             }
         }, start, end, flags)
     }


### PR DESCRIPTION
Green color was inherited froth the host application theme and by default set to green. Removing "super" call prevents picking color from the Theme. 