### PR TITLE
Hotfix/add background color

### DIFF
--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/core/models/PlacementsConfiguration.kt
@@ -42,6 +42,7 @@ data class PopUpStyling(
     val crossColor: Int = Color.BLACK,
     val dividerColor: Int = LIGHT_GRAY_COLOR,
     val borderColor: Int = LIGHT_GRAY_COLOR,
+    val backgroundColor: Int = Color.WHITE,
     val titlePopupTextStyle: PopupTextStyle = PopupTextStyle(
         textColor = Color.BLACK,
         textSize = BreadPartnerDefaults.TITLE_POPUP_TEXT_SIZE

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
@@ -177,7 +177,9 @@ fun PopupDialog.setupUI() {
         disclosureLabel.makeLinksClickable(linkClickHandler)
 
         PopupElements.shared.decorateLinearLayout(
-            linearLayout = contentContainer, borderColor = popupStyle.borderColor
+            linearLayout = contentContainer,
+            borderColor = popupStyle.borderColor,
+            backgroundColor = popupStyle.backgroundColor,
         )
         headerView.setBackgroundColor(Color.GRAY)
         PopupElements.shared.decorateLinearLayout(

--- a/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
+++ b/BreadPartnersSDK/src/main/java/com/breadfinancial/breadpartners/sdk/htmlhandling/uicomponents/popup/extensions/PopupUIExtension.kt
@@ -62,8 +62,8 @@ private fun TextView.makeLinksClickable(onLinkClicked: (url: String) -> Unit) {
                 onLinkClicked(url)
             }
             override fun updateDrawState(ds: TextPaint) {
-                super.updateDrawState(ds)
                 ds.isUnderlineText = true
+                ds.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
             }
         }, start, end, flags)
     }


### PR DESCRIPTION
Added an optional parameter "backgroundColor" to the custom styling for a pop up.

<img width="270" height="480" alt="Android match web 1" src="https://github.com/user-attachments/assets/21445730-cb4a-471a-b471-45695fc8b6e9" />
<img width="270" height="480" alt="Android with background color" src="https://github.com/user-attachments/assets/27d43404-cc70-4d86-97e8-aae10a23a207" />
